### PR TITLE
Fix resume parsing request to use file attachment

### DIFF
--- a/supabase/functions/parse-resume/index.ts
+++ b/supabase/functions/parse-resume/index.ts
@@ -287,9 +287,13 @@ async function extractPDFTextWithOpenAI(fileData: Blob): Promise<string> {
           },
           {
             role: 'user',
-            content: `Please extract all text content from this resume PDF. File ID: ${fileId}`
+            content: [
+              { type: 'text', text: 'Please extract all text content from this resume PDF:' },
+              { type: 'file', file_id: fileId }
+            ]
           }
         ],
+        files: [fileId],
         max_tokens: 4000,
         temperature: 0
       }),


### PR DESCRIPTION
## Summary
- attach uploaded PDF file to OpenAI chat request using the new format

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6855969e65d083329c8e75ddee5563d8