### PR TITLE
Add XHR polyfill for parse-resume

### DIFF
--- a/supabase/functions/parse-resume/index.ts
+++ b/supabase/functions/parse-resume/index.ts
@@ -1,3 +1,4 @@
+import "https://deno.land/x/xhr@0.1.0/mod.ts";
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 


### PR DESCRIPTION
## Summary
- import the `xhr` polyfill at the top of `parse-resume`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685596a281648332982328eeff713da7