### PR TITLE
Update NotFound page to use Link

### DIFF
--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,4 +1,4 @@
-import { useLocation } from "react-router-dom";
+import { useLocation, Link } from "react-router-dom";
 import { useEffect } from "react";
 
 const NotFound = () => {
@@ -16,9 +16,7 @@ const NotFound = () => {
       <div className="text-center">
         <h1 className="text-4xl font-bold mb-4">404</h1>
         <p className="text-xl text-gray-600 mb-4">Oops! Page not found</p>
-        <a href="/" className="text-blue-500 hover:text-blue-700 underline">
-          Return to Home
-        </a>
+        <Link to="/">Return to Home</Link>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- replace anchor element with `<Link>` on NotFound page
- import `Link` from `react-router-dom`

## Testing
- `npm install` *(fails: unable to fetch packages)*

------
https://chatgpt.com/codex/tasks/task_e_68562ea4fcfc8332b32163152df355c4