### PR TITLE
Apply dashboard layout to utility pages

### DIFF
--- a/src/components/dashboard/DashboardPageLayout.tsx
+++ b/src/components/dashboard/DashboardPageLayout.tsx
@@ -1,0 +1,18 @@
+import { useState } from "react";
+import { DashboardLayout } from "@/components/dashboard/DashboardLayout";
+
+interface DashboardPageLayoutProps {
+  children: React.ReactNode;
+}
+
+const DashboardPageLayout: React.FC<DashboardPageLayoutProps> = ({ children }) => {
+  const [activeTab, setActiveTab] = useState("profile");
+
+  return (
+    <DashboardLayout activeTab={activeTab} onTabChange={setActiveTab}>
+      {children}
+    </DashboardLayout>
+  );
+};
+
+export default DashboardPageLayout;

--- a/src/pages/DataManagement.tsx
+++ b/src/pages/DataManagement.tsx
@@ -1,18 +1,21 @@
 
 import React from 'react';
 import { DataManagement as DataManagementComponent } from '@/components/DataManagement';
+import DashboardPageLayout from '@/components/dashboard/DashboardPageLayout';
 
 const DataManagement = () => {
   return (
-    <div className="container mx-auto py-8 px-4">
-      <div className="mb-8">
-        <h1 className="text-3xl font-bold mb-2">Data Management</h1>
-        <p className="text-muted-foreground">
-          Manage your personal data and privacy settings
-        </p>
+    <DashboardPageLayout>
+      <div className="container mx-auto py-8 px-4">
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold mb-2">Data Management</h1>
+          <p className="text-muted-foreground">
+            Manage your personal data and privacy settings
+          </p>
+        </div>
+        <DataManagementComponent />
       </div>
-      <DataManagementComponent />
-    </div>
+    </DashboardPageLayout>
   );
 };
 

--- a/src/pages/ResumeUpload.tsx
+++ b/src/pages/ResumeUpload.tsx
@@ -1,21 +1,24 @@
 
 import React from 'react';
 import { ResumeUpload as ResumeUploadComponent } from '@/components/ResumeUpload';
+import DashboardPageLayout from '@/components/dashboard/DashboardPageLayout';
 
 const ResumeUpload = () => {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-900 dark:to-gray-800 p-4">
-      <div className="container mx-auto py-8">
-        <div className="mb-8 text-center">
-          <h1 className="text-3xl font-bold tracking-tight">Resume Analysis</h1>
-          <p className="text-muted-foreground mt-2">
-            Upload your resume to automatically extract and analyze your career data
-          </p>
+    <DashboardPageLayout>
+      <div className="p-4">
+        <div className="container mx-auto py-8">
+          <div className="mb-8 text-center">
+            <h1 className="text-3xl font-bold tracking-tight">Resume Analysis</h1>
+            <p className="text-muted-foreground mt-2">
+              Upload your resume to automatically extract and analyze your career data
+            </p>
+          </div>
+
+          <ResumeUploadComponent />
         </div>
-        
-        <ResumeUploadComponent />
       </div>
-    </div>
+    </DashboardPageLayout>
   );
 };
 


### PR DESCRIPTION
## Summary
- add `DashboardPageLayout` wrapper for common sidebar
- show sidebar on Data Management page
- show sidebar on Resume Upload page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68562e91fe048332bc1edf22582f2e38